### PR TITLE
Add serialization tests for RewindSnapshot

### DIFF
--- a/Assets/Scripts/Rewind/RewindSnapshot.cs
+++ b/Assets/Scripts/Rewind/RewindSnapshot.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 namespace ChronoCore.Rewind
 {
+    [System.Serializable]
     public struct RewindSnapshot
     {
               public Vector2 Position;

--- a/Assets/Tests/PlayMode/RewindSnapshotTests.cs
+++ b/Assets/Tests/PlayMode/RewindSnapshotTests.cs
@@ -1,0 +1,71 @@
+using NUnit.Framework;
+using UnityEngine;
+using ChronoCore.Rewind;
+
+[TestFixture]
+public class RewindSnapshotTests
+{
+    [Test]
+    public void Serialization_Preserves_Values()
+    {
+        // Arrange
+        RewindSnapshot originalSnapshot = new RewindSnapshot
+        {
+            Position = new Vector2(1.5f, -2.5f),
+            Velocity = new Vector2(3.0f, 0.0f),
+            Health = 50,
+            IsActive = true,
+            AnimatorStateHash = 123456,
+            AnimatorNormTime = 0.5f,
+            DashCooldownTimer = 1.2f,
+            IFrameTimer = 0.3f,
+            ChronoEnergyAmount = 100.0f,
+            CustomIntA = 42,
+            CustomFloatA = 3.14f,
+            CustomBoolA = true
+        };
+
+        // Act
+        string json = JsonUtility.ToJson(originalSnapshot);
+        RewindSnapshot deserializedSnapshot = JsonUtility.FromJson<RewindSnapshot>(json);
+
+        // Assert
+        Assert.AreEqual(originalSnapshot.Position, deserializedSnapshot.Position);
+        Assert.AreEqual(originalSnapshot.Velocity, deserializedSnapshot.Velocity);
+        Assert.AreEqual(originalSnapshot.Health, deserializedSnapshot.Health);
+        Assert.AreEqual(originalSnapshot.IsActive, deserializedSnapshot.IsActive);
+        Assert.AreEqual(originalSnapshot.AnimatorStateHash, deserializedSnapshot.AnimatorStateHash);
+        Assert.AreEqual(originalSnapshot.AnimatorNormTime, deserializedSnapshot.AnimatorNormTime);
+        Assert.AreEqual(originalSnapshot.DashCooldownTimer, deserializedSnapshot.DashCooldownTimer);
+        Assert.AreEqual(originalSnapshot.IFrameTimer, deserializedSnapshot.IFrameTimer);
+        Assert.AreEqual(originalSnapshot.ChronoEnergyAmount, deserializedSnapshot.ChronoEnergyAmount);
+        Assert.AreEqual(originalSnapshot.CustomIntA, deserializedSnapshot.CustomIntA);
+        Assert.AreEqual(originalSnapshot.CustomFloatA, deserializedSnapshot.CustomFloatA);
+        Assert.AreEqual(originalSnapshot.CustomBoolA, deserializedSnapshot.CustomBoolA);
+    }
+
+    [Test]
+    public void Default_Values_Serialization()
+    {
+        // Arrange
+        RewindSnapshot originalSnapshot = new RewindSnapshot(); // Default constructor
+
+        // Act
+        string json = JsonUtility.ToJson(originalSnapshot);
+        RewindSnapshot deserializedSnapshot = JsonUtility.FromJson<RewindSnapshot>(json);
+
+        // Assert
+        Assert.AreEqual(originalSnapshot.Position, deserializedSnapshot.Position);
+        Assert.AreEqual(originalSnapshot.Velocity, deserializedSnapshot.Velocity);
+        Assert.AreEqual(originalSnapshot.Health, deserializedSnapshot.Health);
+        Assert.AreEqual(originalSnapshot.IsActive, deserializedSnapshot.IsActive);
+        Assert.AreEqual(originalSnapshot.AnimatorStateHash, deserializedSnapshot.AnimatorStateHash);
+        Assert.AreEqual(originalSnapshot.AnimatorNormTime, deserializedSnapshot.AnimatorNormTime);
+        Assert.AreEqual(originalSnapshot.DashCooldownTimer, deserializedSnapshot.DashCooldownTimer);
+        Assert.AreEqual(originalSnapshot.IFrameTimer, deserializedSnapshot.IFrameTimer);
+        Assert.AreEqual(originalSnapshot.ChronoEnergyAmount, deserializedSnapshot.ChronoEnergyAmount);
+        Assert.AreEqual(originalSnapshot.CustomIntA, deserializedSnapshot.CustomIntA);
+        Assert.AreEqual(originalSnapshot.CustomFloatA, deserializedSnapshot.CustomFloatA);
+        Assert.AreEqual(originalSnapshot.CustomBoolA, deserializedSnapshot.CustomBoolA);
+    }
+}


### PR DESCRIPTION
This PR adds a test suite for `RewindSnapshot` serialization and fixes a missing `[System.Serializable]` attribute that would prevent `RewindSnapshot` from being serialized by Unity's `JsonUtility`.

Changes:
- **Added:** `Assets/Tests/PlayMode/RewindSnapshotTests.cs` containing `Serialization_Preserves_Values` and `Default_Values_Serialization` tests.
- **Modified:** `Assets/Scripts/Rewind/RewindSnapshot.cs` to include the `[System.Serializable]` attribute.

Tests Verified:
- Manually verified code structure and logic as runtime environment lacks Unity Editor.
- Confirmed `JsonUtility` requires `[Serializable]` for custom structs.

---
*PR created automatically by Jules for task [14290190320239667348](https://jules.google.com/task/14290190320239667348) started by @MikeDeCristofaro*